### PR TITLE
fixing mesa-9999 patch file

### DIFF
--- a/media-libs/mesa/files/mesa-9999-dont-require-llvm-for-r300.patch
+++ b/media-libs/mesa/files/mesa-9999-dont-require-llvm-for-r300.patch
@@ -1,25 +1,12 @@
---- a/configure.ac	2012-05-12 11:50:09.786970584 +0200
-+++ b/configure.ac	2012-05-12 12:00:00.770582272 +0200
-@@ -1922,14 +1922,6 @@
-     fi
- }
- 
--gallium_require_llvm() {
--    if test "x$MESA_LLVM" = x0; then
--        case "$host_cpu" in
--        i*86|x86_64) AC_MSG_ERROR([LLVM is required to build $1 on x86 and x86_64]);;
--        esac
--    fi
--}
--
- gallium_require_drm_loader() {
-     if test "x$enable_gallium_loader" = xyes; then
-         PKG_CHECK_MODULES([LIBUDEV], [libudev], [],
-@@ -1962,7 +1954,6 @@
-             ;;
+diff --git a/configure.ac b/configure.ac
+index 21a1986..94b2247 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -1777,7 +1777,6 @@ if test "x$with_gallium_drivers" != x; then
          xr300)
+             HAVE_GALLIUM_R300=yes
              PKG_CHECK_MODULES([RADEON], [libdrm_radeon >= $LIBDRM_RADEON_REQUIRED])
 -            gallium_require_llvm "Gallium R300"
              GALLIUM_DRIVERS_DIRS="$GALLIUM_DRIVERS_DIRS r300"
-             gallium_check_st "radeon/drm" "dri-r300" "xorg-r300" "" "xvmc-r300" "vdpau-r300" "va-r300"
+             gallium_check_st "radeon/drm" "dri-r300" "" "" "xvmc-r300" "vdpau-r300"
              ;;


### PR DESCRIPTION
Updating mesa-9999-dont-require-llvm-for-r300.patch to work with current
upstream

See #24 
