### PR TITLE
www-client/chromium: Fix building with GCC-9

### DIFF
--- a/www-client/chromium/chromium-75.0.3770.27.ebuild
+++ b/www-client/chromium/chromium-75.0.3770.27.ebuild
@@ -146,6 +146,9 @@ PATCHES=(
 	"${FILESDIR}/chromium-deconst.patch"
 	"${FILESDIR}/chromium-75-vr-fix.patch"
 	"${FILESDIR}/chromium-75-libstdc.patch"
+	"${FILESDIR}/chromium-73.0.3683.86-system_icu_array_size_calculation_minimalistic_fix.patch"
+	"${FILESDIR}/chromium-75-noexcept-false.patch"
+	"${FILESDIR}/chromium-75-define-compiler_gcc.patch"
 )
 
 pre_build_checks() {
@@ -380,8 +383,8 @@ src_prepare() {
 	build/linux/unbundle/remove_bundled_libraries.py "${keeplibs[@]}" --do-remove || die
 
 	# Turn back lss.h. see https://chromium-review.googlesource.com/c/crashpad/crashpad/+/1559309
-	cp ${FILESDIR}/BUILD.gn third_party/lss/BUILD.gn
-	cp ${FILESDIR}/lss.h third_party/lss/lss.h
+	cp "${FILESDIR}"/BUILD.gn third_party/lss/BUILD.gn
+	cp "${FILESDIR}"/lss.h third_party/lss/lss.h
 }
 
 src_configure() {

--- a/www-client/chromium/files/chromium-73.0.3683.86-system_icu_array_size_calculation_minimalistic_fix.patch
+++ b/www-client/chromium/files/chromium-73.0.3683.86-system_icu_array_size_calculation_minimalistic_fix.patch
@@ -1,0 +1,138 @@
+Chromium contains at least 2 ways of array size calculation:
+
+base/stl_util.h contains:
+[[[
+namespace base {
+...
+template <typename T, size_t N>
+constexpr size_t size(const T (&array)[N]) noexcept {
+  return N;
+}
+...
+}
+]]]
+
+third_party/blink/renderer/platform/text/character_property_data_generator.cc contains:
+[[[
+#define ARRAY_LENGTH(a) (sizeof(a) / sizeof((a)[0]))
+]]]
+
+
+In C++, zero-length arrays can be defined, but some operations on them are not permitted
+(by either Clang or GCC, even in GNU mode (-std=gnu++...)):
+[[[
+$ cat test.h
+#include <cstddef>
+
+namespace base {
+
+template <typename T, size_t N>
+constexpr size_t size(const T (&array)[N]) noexcept {
+  return N;
+}
+
+}
+
+#define ARRAY_LENGTH(a) (sizeof(a) / sizeof((a)[0]))
+
+int non_empty_array[] = {1, 3, 5, 7, 9};
+int empty_array[] = {};
+$ cat test_base::size_1.cpp
+#include "test.h"
+
+int main() {
+  size_t x = base::size(non_empty_array);
+}
+$ cat test_base::size_2.cpp
+#include "test.h"
+
+int main() {
+  size_t x = base::size(empty_array);
+}
+$ cat test_ARRAY_LENGTH_1.cpp
+#include "test.h"
+
+int main() {
+  size_t x = ARRAY_LENGTH(non_empty_array);
+}
+$ cat test_ARRAY_LENGTH_2.cpp
+#include "test.h"
+
+int main() {
+  size_t x = ARRAY_LENGTH(empty_array);
+}
+$ g++-8.3.0 -std=gnu++17 test_base::size_1.cpp
+$ clang++-8 -std=gnu++17 test_base::size_1.cpp
+$ g++-8.3.0 -std=gnu++17 test_base::size_2.cpp
+test_base::size_2.cpp: In function ‘int main()’:
+test_base::size_2.cpp:4:36: error: no matching function for call to ‘size(int [0])’
+   size_t x = base::size(empty_array);
+                                    ^
+In file included from test_base::size_2.cpp:1:
+test.h:6:18: note: candidate: ‘template<class T, long unsigned int N> constexpr size_t base::size(const T (&)[N])’
+ constexpr size_t size(const T (&array)[N]) noexcept {
+                  ^~~~
+test.h:6:18: note:   template argument deduction/substitution failed:
+$ clang++-8 -std=gnu++17 test_base::size_2.cpp
+test_base::size_2.cpp:4:14: error: no matching function for call to 'size'
+  size_t x = base::size(empty_array);
+             ^~~~~~~~~~
+./test.h:6:18: note: candidate template ignored: substitution failure [with T = int, N = 0]: zero-length arrays are not permitted in C++
+constexpr size_t size(const T (&array)[N]) noexcept {
+                 ^                     ~
+1 error generated.
+$ g++-8.3.0 -std=gnu++17 test_ARRAY_LENGTH_1.cpp
+$ clang++-8 -std=gnu++17 test_ARRAY_LENGTH_1.cpp
+$ g++-8.3.0 -std=gnu++17 test_ARRAY_LENGTH_2.cpp
+$ clang++-8 -std=gnu++17 test_ARRAY_LENGTH_2.cpp
+]]]
+
+As seen above, base::size() works with non-zero-length arrays and fails with zero-length arrays,
+while ARRAY_LENGTH() works with both non-zero-length arrays and zero-length arrays.
+
+
+third_party/blink/renderer/platform/text/character_property_data.h defines several arrays.
+kIsHangulArray is a zero-length array.
+
+When Chromium is being built with bundled ICU, then array size calculation occurs
+in third_party/blink/renderer/platform/text/character_property_data_generator.cc
+in GenerateCharacterPropertyData() function,
+which (through SET macro) uses ARRAY_LENGTH(), which works with zero-length arrays.
+
+When Chromium is being built with system ICU, then array size calculation occurs
+in third_party/blink/renderer/platform/text/character.cc in several functions,
+which (through RETURN_HAS_PROPERTY and CREATE_UNICODE_SET macros) use base::size(), which fails with zero-length arrays.
+
+The minimalistic fix is to make third_party/blink/renderer/platform/text/character.cc also use ARRAY_LENGTH() instead of base::size().
+
+--- /third_party/blink/renderer/platform/text/character.cc
++++ /third_party/blink/renderer/platform/text/character.cc
+@@ -63,9 +63,13 @@
+   return unicodeSet;
+ }
+ 
+-#define CREATE_UNICODE_SET(name)                                       \
+-  createUnicodeSet(name##Array, base::size(name##Array), name##Ranges, \
+-                   base::size(name##Ranges))
++// base::size (from base/stl_util.h) causes compilation errors
++// with zero-length arrays.
++#define ARRAY_LENGTH(a) (sizeof(a) / sizeof((a)[0]))
++
++#define CREATE_UNICODE_SET(name)                             \
++  createUnicodeSet(name##Array, ARRAY_LENGTH(name##Array),   \
++                   name##Ranges, ARRAY_LENGTH(name##Ranges))
+ 
+ #define RETURN_HAS_PROPERTY(c, name)            \
+   static icu::UnicodeSet* unicodeSet = nullptr; \
+--- /third_party/blink/renderer/platform/text/character_property_data_generator.cc
++++ /third_party/blink/renderer/platform/text/character_property_data_generator.cc
+@@ -22,6 +22,9 @@
+ #else
+ 
+ const UChar32 kMaxCodepoint = 0x10FFFF;
++
++// base::size (from base/stl_util.h) causes compilation errors
++// with zero-length arrays.
+ #define ARRAY_LENGTH(a) (sizeof(a) / sizeof((a)[0]))
+ 
+ static void SetRanges(CharacterProperty* values,

--- a/www-client/chromium/files/chromium-75-define-compiler_gcc.patch
+++ b/www-client/chromium/files/chromium-75-define-compiler_gcc.patch
@@ -1,0 +1,18 @@
+COMPILER_GCC isn't defined in 'third_party/angle/src/common/debug.h' causing it to use
+MSVC/LLVM intrinsics that don't exist in GCC, leading to:
+
+../../third_party/angle/src/common/debug.h:254:62: error: ‘__assume’ was not declared in this scope
+
+Including 'build/build_config.h' correctly defines COMPILER_GCC
+
+--- a/third_party/angle/src/common/debug.h
++++ b/third_party/angle/src/common/debug.h
+@@ -18,6 +18,8 @@
+ #include <sstream>
+ #include <string>
+ 
++#include "../../../../build/build_config.h"
++
+ #include "common/angleutils.h"
+ #include "common/platform.h"
+ 

--- a/www-client/chromium/files/chromium-75-noexcept-false.patch
+++ b/www-client/chromium/files/chromium-75-noexcept-false.patch
@@ -1,0 +1,25 @@
+Bug: https://bugs.chromium.org/p/chromium/issues/detail?id=962163
+
+--- a/components/omnibox/browser/autocomplete_match.cc
++++ b/components/omnibox/browser/autocomplete_match.cc
+@@ -154,8 +154,7 @@
+       additional_info(match.additional_info),
+       duplicate_matches(match.duplicate_matches) {}
+ 
+-AutocompleteMatch::AutocompleteMatch(AutocompleteMatch&& match) noexcept =
+-    default;
++AutocompleteMatch::AutocompleteMatch(AutocompleteMatch&& match) = default;
+ 
+ AutocompleteMatch::~AutocompleteMatch() {
+ }
+--- a/components/omnibox/browser/autocomplete_match.h
++++ b/components/omnibox/browser/autocomplete_match.h
+@@ -143,7 +143,7 @@
+                     bool deletable,
+                     Type type);
+   AutocompleteMatch(const AutocompleteMatch& match);
+-  AutocompleteMatch(AutocompleteMatch&& match) noexcept;
++  AutocompleteMatch(AutocompleteMatch&& match);
+   ~AutocompleteMatch();
+ 
+   AutocompleteMatch& operator=(const AutocompleteMatch& match);


### PR DESCRIPTION
I'm not sure how desired it is but the following changes enable building chromium-75.0.3770.27 with GCC-9.1.0 on my end. 

Built with: 
**USE**="closure-compile cups custom-cflags* (pic) proprietary-codecs pulseaudio suid system-ffmpeg system-icu system-libvpx vaapi%* widevine -component-build -gnome-keyring -hangouts -jumbo-build -kerberos (-neon) (-selinux) (-tcmalloc)" L10N="-am -ar -bg -bn -ca -cs -da -de -el -en-GB -es -es-419 -et -fa -fi -fil -fr -gu -he -hi -hr -hu -id -it -ja -kn -ko -lt -lv -ml -mr -ms -nb -nl -pl -pt-BR -pt-PT -ro -ru -sk -sl -sr -sv -sw -ta -te -th -tr -uk -vi -zh-CN -zh-TW"

**C{XX}FLAGS**="-march=skylake -mabm --param l1-cache-size=32 --param l1-cache-line-size=64 --param l2-cache-size=6144 -O2 -pipe"


**chromium-73.0.3683.86-system_icu_array_size_calculation_minimalistic_fix.patch** was taken directly from https://bugs.gentoo.org/661880 and appears to fix the following build error:
```
../../third_party/blink/renderer/platform/text/character.cc:67:55: error: no matching function for call to ‘size(const UChar32 [0])’
   67 |   createUnicodeSet(name##Array, base::size(name##Array), name##Ranges, \
      |                                                       ^
../../third_party/blink/renderer/platform/text/character.cc:73:18: note: in expansion of macro ‘CREATE_UNICODE_SET’
   73 |     unicodeSet = CREATE_UNICODE_SET(name);      \
      |                  ^~~~~~~~~~~~~~~~~~
../../third_party/blink/renderer/platform/text/character.cc:124:3: note: in expansion of macro ‘RETURN_HAS_PROPERTY’
  124 |   RETURN_HAS_PROPERTY(character, kIsHangul);
      |   ^~~~~~~~~~~~~~~~~~~
```

**chromium-75-noexcept-false.patch** fixes:

```
../../components/omnibox/browser/autocomplete_match.cc:157:1: error: function ‘AutocompleteMatch::AutocompleteMatch(AutocompleteMatch&&)’ defaulted on its redeclaration with an exception-specification that differs from the implicit exception-specification ‘noexcept (false)’
  157 | AutocompleteMatch::AutocompleteMatch(AutocompleteMatch&& match) noexcept =
      | ^~~~~~~~~~~~~~~~~
```
reported upstream at https://bugs.chromium.org/p/chromium/issues/detail?id=962163.  

**chromium-75-define-compiler_gcc.patch** fixes:
```
In file included from ../../third_party/angle/src/common/debug.cpp:9:
../../third_party/angle/src/common/debug.cpp: In destructor ‘gl::LogMessage::~LogMessage()’:
../../third_party/angle/src/common/debug.h:254:62: error: ‘__assume’ was not declared in this scope
  254 | #    define ANGLE_CRASH() ((void)(*(volatile char *)0 = 0)), __assume(0)
      |                                                              ^~~~~~~~
../../third_party/angle/src/common/debug.cpp:171:9: note: in expansion of macro ‘ANGLE_CRASH’
  171 |         ANGLE_CRASH();
      |         ^~~~~~~~~~~

```

Sadly, shortly after it runs, it terminates.  I don't have a system with the resources necessary to build with debugging symbols to even attempt to debug it.

Package-Manager: Portage-2.3.66, Repoman-2.3.12